### PR TITLE
Make sharing easier

### DIFF
--- a/user_external/lib/base.php
+++ b/user_external/lib/base.php
@@ -82,7 +82,7 @@ abstract class Base extends \OC_User_Backend{
 				'limit'  => $limit,
 				'offset' => $offset
 			),
-			array($search . '%', $search . '%', $this->backend)
+			array('%' . $search . '%', '%' . $search . '%', $this->backend)
 		);
 
 		$displayNames = array();


### PR DESCRIPTION
Now Users have just to enter a part of the name. e.g. 'do' for 'John Doe'.
see also: owncloud/core#11256
